### PR TITLE
Testplan.pm - Implement cli flag --id

### DIFF
--- a/lib/Tapper/CLI/Testplan.pm
+++ b/lib/Tapper/CLI/Testplan.pm
@@ -123,7 +123,9 @@ sub testplanlist
         my $format    = $c->options->{format};
 
         require Tapper::Model;
-        if (@{$c->options->{testrun} || []}) {
+        if (@($c->options->{id} || []}) {
+                @ids = @{$c->options->{id}};
+        } elsif (@{$c->options->{testrun} || []}) {
                 my $testruns = Tapper::Model::model('TestrunDB')->resultset('Testrun')->search({id => $c->options->{testrun}});
                 while (my $testrun = $testruns->next) {
                         push @ids, $testrun->testplan_id if $testrun->testplan_id;


### PR DESCRIPTION
Although it being documented in the help, the cli flag --id did up
until now not did not have any influence on the data gathered when
listing testplans. This commit implements the --id cli flag by using
the specified IDs as provided like they were just gathered from the
database into @ids. This provides the rest of the testplanlist
subroutine with the necessary filter requested by the user.